### PR TITLE
add alpha decay to reduce gradually the penalties

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     sampler::Sampler, FinishReason, GenerateRequest, OptionArray, ThreadRequest, ThreadState,
-    Token, TokenCounter, MAX_PENALTY_COUNT, ALPHA_DECAY
+    Token, TokenCounter, ALPHA_DECAY, MAX_PENALTY_COUNT,
 };
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -149,12 +149,11 @@ async fn chat_completions_one(
         .map(|record| record.content)
         .join("\n\n");
     let model_tokens = tokenizer.encode(model_text.as_bytes()).unwrap_or_default();
-    let mut occurrences:HashMap<u16, f32> = HashMap::new();
+    let mut occurrences: HashMap<u16, f32> = HashMap::new();
     for key in model_tokens.iter().take(MAX_PENALTY_COUNT) {
         if occurrences.contains_key(key) {
             occurrences.insert(*key, occurrences[key] + 1.0);
-        }
-        else {
+        } else {
             occurrences.insert(*key, 1.0);
         }
         for (_, count) in occurrences.iter_mut() {
@@ -244,12 +243,11 @@ async fn chat_completions_stream(
         .map(|record| record.content)
         .join("\n\n");
     let model_tokens = tokenizer.encode(model_text.as_bytes()).unwrap_or_default();
-    let mut occurrences:HashMap<u16, f32> = HashMap::new();
+    let mut occurrences: HashMap<u16, f32> = HashMap::new();
     for key in model_tokens.iter().take(MAX_PENALTY_COUNT) {
         if occurrences.contains_key(key) {
             occurrences.insert(*key, occurrences[key] + 1.0);
-        }
-        else {
+        } else {
             occurrences.insert(*key, 1.0);
         }
         for (_, count) in occurrences.iter_mut() {

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     sampler::Sampler, FinishReason, GenerateRequest, OptionArray, ThreadRequest, ThreadState,
-    Token, TokenCounter, MAX_PENALTY_COUNT,
+    Token, TokenCounter, MAX_PENALTY_COUNT, ALPHA_DECAY
 };
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -149,11 +149,18 @@ async fn chat_completions_one(
         .map(|record| record.content)
         .join("\n\n");
     let model_tokens = tokenizer.encode(model_text.as_bytes()).unwrap_or_default();
-    let occurrences = model_tokens
-        .into_iter()
-        .rev()
-        .take(MAX_PENALTY_COUNT)
-        .counts();
+    let mut occurrences:HashMap<u16, f32> = HashMap::new();
+    for key in model_tokens.iter().take(MAX_PENALTY_COUNT) {
+        if occurrences.contains_key(key) {
+            occurrences.insert(*key, occurrences[key] + 1.0);
+        }
+        else {
+            occurrences.insert(*key, 1.0);
+        }
+        for (_, count) in occurrences.iter_mut() {
+            *count = *count * ALPHA_DECAY;
+        }
+    }
     let request = request.into();
 
     let _ = sender.send(ThreadRequest::Generate {
@@ -237,11 +244,18 @@ async fn chat_completions_stream(
         .map(|record| record.content)
         .join("\n\n");
     let model_tokens = tokenizer.encode(model_text.as_bytes()).unwrap_or_default();
-    let occurrences = model_tokens
-        .into_iter()
-        .rev()
-        .take(MAX_PENALTY_COUNT)
-        .counts();
+    let mut occurrences:HashMap<u16, f32> = HashMap::new();
+    for key in model_tokens.iter().take(MAX_PENALTY_COUNT) {
+        if occurrences.contains_key(key) {
+            occurrences.insert(*key, occurrences[key] + 1.0);
+        }
+        else {
+            occurrences.insert(*key, 1.0);
+        }
+        for (_, count) in occurrences.iter_mut() {
+            *count = *count * ALPHA_DECAY;
+        }
+    }
     let request = request.into();
 
     let _ = sender.send(ThreadRequest::Generate {

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     sampler::Sampler, FinishReason, GenerateRequest, OptionArray, ThreadRequest, ThreadState,
-    Token, TokenCounter, MAX_PENALTY_COUNT, ALPHA_DECAY
+    Token, TokenCounter, ALPHA_DECAY, MAX_PENALTY_COUNT,
 };
 
 #[derive(Debug, Deserialize)]
@@ -108,12 +108,11 @@ async fn completions_one(
     let tokens = tokenizer
         .encode(request.prompt.as_bytes())
         .unwrap_or_default();
-    let mut occurrences:HashMap<u16, f32> = HashMap::new();
+    let mut occurrences: HashMap<u16, f32> = HashMap::new();
     for key in tokens.iter().take(MAX_PENALTY_COUNT) {
         if occurrences.contains_key(key) {
             occurrences.insert(*key, occurrences[key] + 1.0);
-        }
-        else {
+        } else {
             occurrences.insert(*key, 1.0);
         }
         for (_, count) in occurrences.iter_mut() {
@@ -195,12 +194,11 @@ async fn completions_stream(
     let tokens = tokenizer
         .encode(request.prompt.as_bytes())
         .unwrap_or_default();
-    let mut occurrences:HashMap<u16, f32> = HashMap::new();
+    let mut occurrences: HashMap<u16, f32> = HashMap::new();
     for key in tokens.iter().take(MAX_PENALTY_COUNT) {
         if occurrences.contains_key(key) {
             occurrences.insert(*key, occurrences[key] + 1.0);
-        }
-        else {
+        } else {
             occurrences.insert(*key, 1.0);
         }
         for (_, count) in occurrences.iter_mut() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,7 @@ use crate::sampler::Sampler;
 pub const MAX_TOKENS: usize = 4096;
 pub const MAX_PENALTY_COUNT: usize = 1024;
 pub const STATE_CACHE_LRU: usize = 16;
+pub const ALPHA_DECAY: f32 = 0.995;
 
 #[derive(Debug)]
 pub enum Token {
@@ -88,7 +89,7 @@ pub enum ThreadRequest {
     Reload(ReloadRequest),
     Generate {
         request: GenerateRequest,
-        occurrences: HashMap<u16, usize>,
+        occurrences: HashMap<u16, f32>,
         token_sender: flume::Sender<Token>,
     },
 }
@@ -313,13 +314,14 @@ fn model_task(
                 let mut logits = model
                     .run(&context.tensor_from_data(shape, tokens)?, &mask, &state)?
                     .to_vec();
-                for (&token, &count) in occurrences
-                    .iter()
+                for (&token, count) in occurrences
+                    .iter_mut()
                     .filter(|(token, _)| !penalty_free_tokens.contains(token))
                 {
                     let penalty =
-                        sampler.presence_penalty + sampler.frequency_penalty * count as f32;
+                        sampler.presence_penalty + sampler.frequency_penalty * *count;
                     logits[token as usize] -= penalty;
+                    *count = *count * ALPHA_DECAY;
                 }
                 for (&token, &bias) in &logit_bias {
                     logits[token as usize] += bias;
@@ -342,7 +344,7 @@ fn model_task(
                 token_counter.total_tokens += 1;
 
                 let count = occurrences.get(&token).copied().unwrap_or_default();
-                occurrences.insert(token, count + 1);
+                occurrences.insert(token, count + 1.0);
 
                 let _ = token_sender.send(Token::Token(word));
                 tokens = vec![token];

--- a/src/main.rs
+++ b/src/main.rs
@@ -318,8 +318,7 @@ fn model_task(
                     .iter_mut()
                     .filter(|(token, _)| !penalty_free_tokens.contains(token))
                 {
-                    let penalty =
-                        sampler.presence_penalty + sampler.frequency_penalty * *count;
+                    let penalty = sampler.presence_penalty + sampler.frequency_penalty * *count;
                     logits[token as usize] -= penalty;
                     *count = *count * ALPHA_DECAY;
                 }


### PR DESCRIPTION
Hi, this PR adding the alpha decay to reduce the number of each tokens occurrence that is used to calculate the penalties. It means we will reduce the penalties gradually by every step which is important to avoid that generated words are concatenated or gibberish because many token has high penalties after sometimes. This PR is connected to the issue #34.

Since this is my very first Rust PR at all, I believe that my code must contains beginner code, and still need to be corrected or improved, please also review it, thanks :-)
   
