### PR TITLE
improve memory usage and speed of convert_safetensors.py and rwkv 5.1 compatibility

### DIFF
--- a/convert_safetensors.py
+++ b/convert_safetensors.py
@@ -1,9 +1,8 @@
-import json
+import collections
+import numpy
 import os
-import sys
-import copy
 import torch
-from safetensors.torch import load_file, save_file
+from safetensors.torch import serialize_file, load_file
 
 import argparse
 
@@ -26,36 +25,63 @@ def rename_key(rename, name):
 
 
 def convert_file(pt_filename: str, sf_filename: str, rename={}, transpose_names=[]):
-    loaded = torch.load(pt_filename, map_location="cpu")
+    loaded: collections.OrderedDict = torch.load(pt_filename, map_location="cpu")
     if "state_dict" in loaded:
         loaded = loaded["state_dict"]
 
-    loaded = {k: v.clone().half() for k, v in loaded.items()}
-    # for k, v in loaded.items():
-    #     print(f'{k}\t{v.shape}\t{v.dtype}')
+    kk = list(loaded.keys())
+    version = 4
+    for x in kk:
+        if "ln_x" in x:
+            version = max(5, version)
+        if "gate.weight" in x:
+            version = max(5.1, version)
+        if int(version) == 5 and "att.time_decay" in x:
+            if len(loaded[x].shape) > 1:
+                if loaded[x].shape[1] > 1:
+                    version = max(5.2, version)
+        if "time_maa" in x:
+            version = max(6, version)
 
-    loaded = {rename_key(rename, k).lower(): v.contiguous()
-              for k, v in loaded.items()}
-    # For tensors to be contiguous
-    for k, v in loaded.items():
+    print(f"Model detected: v{version:.1f}")
+
+    if version == 5.1:
+        _, n_emb = loaded["emb.weight"].shape
+        for k in kk:
+            if "time_decay" in k or "time_faaaa" in k:
+                # print(k, mm[k].shape)
+                loaded[k] = (
+                    loaded[k].unsqueeze(1).repeat(1, n_emb // loaded[k].shape[0])
+                )
+
+    for k in kk:
+        new_k = rename_key(rename, k).lower()
+        v = loaded[k].half()
+        del loaded[k]
         for transpose_name in transpose_names:
             if transpose_name in k:
-                loaded[k] = v.transpose(0, 1)
-
-    loaded = {k: v.clone().half().contiguous() for k, v in loaded.items()}
-
-    for k, v in loaded.items():
-        print(f"{k}\t{v.shape}\t{v.dtype}")
+                v = v.transpose(0, 1)
+        print(f"{new_k}\t{v.shape}\t{v.dtype}")
+        loaded[new_k] = {
+            "dtype": str(v.dtype).split(".")[-1],
+            "shape": v.shape,
+            "data": v.numpy().tobytes(),
+        }
 
     dirname = os.path.dirname(sf_filename)
     os.makedirs(dirname, exist_ok=True)
-    save_file(loaded, sf_filename, metadata={"format": "pt"})
-    reloaded = load_file(sf_filename)
-    for k in loaded:
-        pt_tensor = loaded[k]
-        sf_tensor = reloaded[k]
-        if not torch.equal(pt_tensor, sf_tensor):
-            raise RuntimeError(f"The output tensors do not match for key {k}")
+    serialize_file(loaded, sf_filename, metadata={"format": "pt"})
+    # reloaded = load_file(sf_filename)
+    # for k in loaded:
+    #     pt_tensor = torch.Tensor(
+    #         numpy.frombuffer(
+    #             bytearray(loaded[k]["data"]),
+    #             dtype=getattr(numpy, loaded[k]["dtype"]),
+    #         ).reshape(loaded[k]["shape"])
+    #     )
+    #     sf_tensor = reloaded[k]
+    #     if not torch.equal(pt_tensor, sf_tensor):
+    #         raise RuntimeError(f"The output tensors do not match for key {k}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
原来的写法会多次复制权重, 内存占用在1-2倍模型体积间频繁波动, 转换速度慢, 内存较少的机子体验比较差, 甚至卡死

现在的写法产物没变化但是体验好door了

另外注释了转换完毕的校验部分, 感觉好像用处不大, 又比较影响体验, 可以看ai00需要是否取消注释
![ec317c66bb2bd90361ccbd82c7c4a533](https://github.com/cgisky1980/ai00_rwkv_server/assets/13366013/de7a5b01-4934-4dc3-b2f5-fa1978d2a6b2)
