### PR TITLE
Check if dirname is non empty before creating directories

### DIFF
--- a/assets/scripts/convert_safetensors.py
+++ b/assets/scripts/convert_safetensors.py
@@ -76,7 +76,8 @@ def convert_file(pt_filename: str, sf_filename: str, rename={}, transpose_names=
             }
 
     dirname = os.path.dirname(sf_filename)
-    os.makedirs(dirname, exist_ok=True)
+    if dirname:
+        os.makedirs(dirname, exist_ok=True)
     serialize_file(loaded, sf_filename, metadata={"format": "pt"})
     # reloaded = load_file(sf_filename)
     # for k in loaded:


### PR DESCRIPTION
Without this check `python assets/scripts/convert_safetensors.py --input rwkv7-g1d-2.9b-20260131-ctx8192.pth --output rwkv7-g1d-2.9b-20260131-ctx8192.st` will fail in a confusing way to the user. Currently the user must do `python assets/scripts/convert_safetensors.py --input rwkv7-g1d-2.9b-20260131-ctx8192.pth --output ./rwkv7-g1d-2.9b-20260131-ctx8192.st`